### PR TITLE
Improve image manifest validation

### DIFF
--- a/functions/source/soci-index-generator-lambda/go.mod
+++ b/functions/source/soci-index-generator-lambda/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/aws/aws-lambda-go v1.36.1
 	github.com/aws/aws-sdk-go v1.44.175
-	github.com/awslabs/soci-snapshotter v0.0.0-20230314131851-ba3498114873
+	github.com/awslabs/soci-snapshotter v0.1.0
 	github.com/containerd/containerd v1.6.19
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/rs/zerolog v1.29.0

--- a/functions/source/soci-index-generator-lambda/go.sum
+++ b/functions/source/soci-index-generator-lambda/go.sum
@@ -4,8 +4,8 @@ github.com/aws/aws-lambda-go v1.36.1 h1:CJxGkL9uKszIASRDxzcOcLX6juzTLoTKtCIgUGcT
 github.com/aws/aws-lambda-go v1.36.1/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
 github.com/aws/aws-sdk-go v1.44.175 h1:c0NzHHnPXV5kJoTUFQxFN5cUPpX1SxO635XnwL5/oIY=
 github.com/aws/aws-sdk-go v1.44.175/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/awslabs/soci-snapshotter v0.0.0-20230314131851-ba3498114873 h1:v7kDEfc7ENjJ9uhwW0Eni0FYNu0wiRSwuZ/2ywcGiJc=
-github.com/awslabs/soci-snapshotter v0.0.0-20230314131851-ba3498114873/go.mod h1:3FWOSLiSEFx9GnFEucRij4TX/zm31Kc2SV/XOPypK+o=
+github.com/awslabs/soci-snapshotter v0.1.0 h1:unLqhcXaQ4dMg2r84jdP1RSf326ba6Oi4XqW+r5Hcs8=
+github.com/awslabs/soci-snapshotter v0.1.0/go.mod h1:3FWOSLiSEFx9GnFEucRij4TX/zm31Kc2SV/XOPypK+o=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/containerd v1.6.19 h1:F0qgQPrG0P2JPgwpxWxYavrVeXAG0ezUIB9Z/4FTUAU=
 github.com/containerd/containerd v1.6.19/go.mod h1:HZCDMn4v/Xl2579/MvtOC2M206i+JJ6VxFWU/NetrGY=

--- a/functions/source/soci-index-generator-lambda/utils/registry/registry.go
+++ b/functions/source/soci-index-generator-lambda/utils/registry/registry.go
@@ -5,8 +5,10 @@ package registry
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -29,7 +31,22 @@ const (
 	MediaTypeDockerManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
 	MediaTypeDockerManifest     = "application/vnd.docker.distribution.manifest.v2+json"
 	MediaTypeOCIManifest        = "application/vnd.oci.image.manifest.v1+json"
+
+	MediaTypeDockerImageConfig = "application/vnd.docker.container.image.v1+json"
+	MediaTypeOCIImageConfig    = "application/vnd.oci.image.config.v1+json"
 )
+
+// When a manifest describes an image, the values of this map are the expected manifest config's media types
+var ImageMediaTypeConfigMap = map[string]string{
+	MediaTypeDockerManifest: MediaTypeDockerImageConfig,
+	MediaTypeOCIManifest:    MediaTypeOCIImageConfig,
+}
+
+// List of media types for images
+var ImageMediaTypes = []string{
+	MediaTypeDockerManifest,
+	MediaTypeOCIManifest,
+}
 
 type Registry struct {
 	registry *remote.Registry
@@ -93,19 +110,97 @@ func (registry *Registry) Push(ctx context.Context, ociStore *oci.Store, indexDe
 	return nil
 }
 
-// Fetch the media type of an artifact
-func (registry *Registry) GetMediaType(ctx context.Context, repositoryName string, reference string) (string, error) {
+// Call registry's headManifest and return the manifest's descriptor
+func (registry *Registry) HeadManifest(ctx context.Context, repositoryName string, reference string) (ocispec.Descriptor, error) {
 	repo, err := registry.registry.Repository(ctx, repositoryName)
 	if err != nil {
-		return "", err
+		return ocispec.Descriptor{}, err
 	}
 
 	descriptor, err := repo.Resolve(ctx, reference)
 	if err != nil {
-		return "", err
+		return descriptor, err
 	}
 
-	return descriptor.MediaType, nil
+	return descriptor, nil
+}
+
+// Call registry's getManifest and return the image's manifest
+// The image reference must be a digest because that's what oras-go FetchReference takes
+func (registry *Registry) GetManifest(ctx context.Context, repositoryName string, digest string) (ocispec.Manifest, error) {
+	repo, err := registry.registry.Repository(ctx, repositoryName)
+	var manifest ocispec.Manifest
+	if err != nil {
+		return manifest, err
+	}
+
+	_, rc, err := repo.FetchReference(ctx, digest)
+	if err != nil {
+		return manifest, err
+	}
+
+	bytes, err := io.ReadAll(rc)
+	if err != nil {
+		return manifest, err
+	}
+
+	err = json.Unmarshal(bytes, &manifest)
+	if err != nil {
+		return manifest, err
+	}
+
+	return manifest, nil
+}
+
+// Validate if a tag or digest is a valid image manifest
+func (registry *Registry) ValidateImageManifest(ctx context.Context, repositoryName string, reference string) error {
+	// We have to use HeadManifest, other than GetManifest, to get the manifest mediaType,
+	// because MediaType is not a required field for OCI image manifest.
+	// ECR still returns mediaType in headManifest.
+	descriptor, err := registry.HeadManifest(ctx, repositoryName, reference)
+	if err != nil {
+		return err
+	}
+
+	manifestMediaTypeValid := false
+	for _, supportedMediaType := range ImageMediaTypes {
+		if descriptor.MediaType == supportedMediaType {
+			manifestMediaTypeValid = true
+			break
+		}
+	}
+
+	if !manifestMediaTypeValid {
+		return fmt.Errorf("Unexpected manifest media type %s, expected one of: %v.", descriptor.MediaType, ImageMediaTypes)
+	}
+
+	// validating config media type
+	manifest, err := registry.GetManifest(ctx, repositoryName, descriptor.Digest.String())
+	if err != nil {
+		return err
+	}
+
+	if !isImage(ctx, descriptor.MediaType, manifest) {
+		return fmt.Errorf("Manifest is not for an image.")
+	}
+
+	return nil
+}
+
+// Check if an manifest is an image manifest
+func isImage(ctx context.Context, manifestMediaType string, manifest ocispec.Manifest) bool {
+	expectedConfigMediaType, found := ImageMediaTypeConfigMap[manifestMediaType]
+	if !found {
+		log.Info(ctx, fmt.Sprintf("Unexpected manifest media type %s, expected one of: %v.", manifest.MediaType, ImageMediaTypes))
+		return false
+	}
+
+	if expectedConfigMediaType != manifest.Config.MediaType {
+		log.Info(ctx, fmt.Sprintf("Unexpected config media type %s, expected %s.", manifest.Config.MediaType, expectedConfigMediaType))
+		return false
+	}
+
+	return true
 }
 
 // Check if a registry is an ECR registry

--- a/functions/source/soci-index-generator-lambda/utils/registry/registry_test.go
+++ b/functions/source/soci-index-generator-lambda/utils/registry/registry_test.go
@@ -113,30 +113,3 @@ func TestGetManifest(t *testing.T) {
 	}
 	doTest("docker.io", "library/redis", "sha256:afd1957d6b59bfff9615d7ec07001afb4eeea39eb341fc777c0caac3fcf52187", expected)
 }
-
-func TestIsImage(t *testing.T) {
-	// making the test context
-	lc := lambdacontext.LambdaContext{}
-	lc.AwsRequestID = "abcd-1234-test-get-manifest"
-	ctx := lambdacontext.NewContext(context.Background(), &lc)
-
-	manifest := ocispec.Manifest{
-		MediaType: MediaTypeDockerImageConfig,
-		Config: ocispec.Descriptor{
-			MediaType: "soci index",
-		},
-	}
-	if isImage(ctx, manifest.MediaType, manifest) {
-		t.Fatalf("soci index is not a valid config media type for an image")
-	}
-
-	manifest = ocispec.Manifest{
-		MediaType: MediaTypeOCIManifest,
-		Config: ocispec.Descriptor{
-			MediaType: MediaTypeOCIImageConfig,
-		},
-	}
-	if !isImage(ctx, manifest.MediaType, manifest) {
-		t.Fatalf("The manifest above is a valid OCI image manifest")
-	}
-}

--- a/functions/source/soci-index-generator-lambda/utils/registry/registry_test.go
+++ b/functions/source/soci-index-generator-lambda/utils/registry/registry_test.go
@@ -5,34 +5,138 @@ package registry
 
 import (
 	"context"
-	"fmt"
-	"github.com/aws/aws-lambda-go/lambdacontext"
 	"testing"
+
+	"github.com/aws/aws-lambda-go/lambdacontext"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func TestGetMediaType(t *testing.T) {
-	do := func(registryUrl string, repository string, digestOrTag string, expectedMediaType string) {
+type ExpectedResponse struct {
+	MediaType string
+	Config    ocispec.Descriptor
+}
+
+func TestHeadManifest(t *testing.T) {
+	doTest := func(registryUrl string, repository string, digestOrTag string, expected ExpectedResponse) {
 		// making the test context
 		lc := lambdacontext.LambdaContext{}
-		lc.AwsRequestID = "abcd-1234"
+		lc.AwsRequestID = "abcd-1234-test-head-manifest"
 		ctx := lambdacontext.NewContext(context.Background(), &lc)
 		registry, err := Init(ctx, registryUrl)
 		if err != nil {
 			panic(err)
 		}
 
-		mediaType, err := registry.GetMediaType(context.Background(), repository, digestOrTag)
+		descriptor, err := registry.HeadManifest(context.Background(), repository, digestOrTag)
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println(mediaType)
-		if mediaType != expectedMediaType {
-			t.Fatalf("Incorrect media type. Expected %s but got %s", expectedMediaType, mediaType)
+		if descriptor.MediaType != expected.MediaType {
+			t.Fatalf("Incorrect manifest media type. Expected %s but got %s", expected.MediaType, descriptor.MediaType)
 		}
 	}
 
-	do("public.ecr.aws", "docker/library/redis", "7", MediaTypeDockerManifestList)
-	do("public.ecr.aws", "lambda/python", "3.10", MediaTypeDockerManifestList)
-	do("public.ecr.aws", "lambda/python", "3.10-x86_64", MediaTypeDockerManifest)
-	do("docker.io", "library/redis", "sha256:afd1957d6b59bfff9615d7ec07001afb4eeea39eb341fc777c0caac3fcf52187", MediaTypeDockerManifest)
+	expected := ExpectedResponse{
+		MediaType: MediaTypeDockerManifestList,
+	}
+	doTest("public.ecr.aws", "docker/library/redis", "7", expected)
+
+	expected = ExpectedResponse{
+		MediaType: MediaTypeDockerManifestList,
+	}
+	doTest("public.ecr.aws", "lambda/python", "3.10", expected)
+
+	expected = ExpectedResponse{
+		MediaType: MediaTypeDockerManifest,
+	}
+	doTest("public.ecr.aws", "lambda/python", "3.10-x86_64", expected)
+
+	expected = ExpectedResponse{
+		MediaType: MediaTypeDockerManifest,
+	}
+	doTest("docker.io", "library/redis", "sha256:afd1957d6b59bfff9615d7ec07001afb4eeea39eb341fc777c0caac3fcf52187", expected)
+}
+
+func TestGetManifest(t *testing.T) {
+	doTest := func(registryUrl string, repository string, digestOrTag string, expected ExpectedResponse) {
+		// making the test context
+		lc := lambdacontext.LambdaContext{}
+		lc.AwsRequestID = "abcd-1234-test-get-manifest"
+		ctx := lambdacontext.NewContext(context.Background(), &lc)
+		registry, err := Init(ctx, registryUrl)
+		if err != nil {
+			panic(err)
+		}
+
+		manifest, err := registry.GetManifest(context.Background(), repository, digestOrTag)
+		if err != nil {
+			panic(err)
+		}
+		if manifest.MediaType != expected.MediaType {
+			t.Fatalf("Incorrect manifest media type. Expected %s but got %s", expected.MediaType, manifest.MediaType)
+		}
+
+		if manifest.Config.MediaType != expected.Config.MediaType {
+			t.Fatalf("Incorrect config's media type. Expected %s but got %s", expected.Config.MediaType, manifest.Config.MediaType)
+		}
+	}
+
+	expected := ExpectedResponse{
+		MediaType: MediaTypeDockerManifestList,
+		Config: ocispec.Descriptor{
+			MediaType: "",
+		},
+	}
+	doTest("public.ecr.aws", "docker/library/redis", "7", expected)
+
+	expected = ExpectedResponse{
+		MediaType: MediaTypeDockerManifestList,
+		Config: ocispec.Descriptor{
+			MediaType: "",
+		},
+	}
+	doTest("public.ecr.aws", "lambda/python", "3.10", expected)
+
+	expected = ExpectedResponse{
+		MediaType: MediaTypeDockerManifest,
+		Config: ocispec.Descriptor{
+			MediaType: MediaTypeDockerImageConfig,
+		},
+	}
+	doTest("public.ecr.aws", "lambda/python", "3.10-x86_64", expected)
+
+	expected = ExpectedResponse{
+		MediaType: MediaTypeDockerManifest,
+		Config: ocispec.Descriptor{
+			MediaType: MediaTypeDockerImageConfig,
+		},
+	}
+	doTest("docker.io", "library/redis", "sha256:afd1957d6b59bfff9615d7ec07001afb4eeea39eb341fc777c0caac3fcf52187", expected)
+}
+
+func TestIsImage(t *testing.T) {
+	// making the test context
+	lc := lambdacontext.LambdaContext{}
+	lc.AwsRequestID = "abcd-1234-test-get-manifest"
+	ctx := lambdacontext.NewContext(context.Background(), &lc)
+
+	manifest := ocispec.Manifest{
+		MediaType: MediaTypeDockerImageConfig,
+		Config: ocispec.Descriptor{
+			MediaType: "soci index",
+		},
+	}
+	if isImage(ctx, manifest.MediaType, manifest) {
+		t.Fatalf("soci index is not a valid config media type for an image")
+	}
+
+	manifest = ocispec.Manifest{
+		MediaType: MediaTypeOCIManifest,
+		Config: ocispec.Descriptor{
+			MediaType: MediaTypeOCIImageConfig,
+		},
+	}
+	if !isImage(ctx, manifest.MediaType, manifest) {
+		t.Fatalf("The manifest above is a valid OCI image manifest")
+	}
 }


### PR DESCRIPTION
By checking if an image manifest's config has a valid media type for images, we're able to skip soci index building for non-image artifacts.

Testing performed:
- I ran unit-ish tests locally
- I deployed the lambdas to personal account, pushed Docker and OCI images, and checked the Cloudwatch logs.