### PR TITLE
Updated runtime to provided.al2

### DIFF
--- a/functions/source/soci-index-generator-lambda/Makefile
+++ b/functions/source/soci-index-generator-lambda/Makefile
@@ -1,7 +1,7 @@
 default:
 	# Use static builds to make sure we don't have library version issues between the build env and lambda
-	GOOS=linux GOARCH=amd64 go build -tags "osusergo netgo static_build" -ldflags '-extldflags "-static"' -o main
-	zip soci_index_generator_lambda.zip main
+	GOOS=linux GOARCH=amd64 go build -tags "osusergo netgo static_build lambda.norpc" -ldflags '-extldflags "-static"' -o bootstrap
+	zip soci_index_generator_lambda.zip bootstrap
 
 test:
 	go test -v ./...

--- a/templates/SociIndexBuilder.yml
+++ b/templates/SociIndexBuilder.yml
@@ -173,7 +173,7 @@ Resources:
       Description: >
         Given an Amazon ECR container repository and image, Lambda generates image SOCI artifacts and pushes to repository.
       Handler: main
-      Runtime: go1.x
+      Runtime: provided.al2
       Role: !GetAtt SociIndexGeneratorLambdaRole.Arn
       Timeout: 900
       Code:


### PR DESCRIPTION
Duplicate due to accidentally closing the previous PR.

### Related Issue
#39

### Proposed Changes
As the `go 1.x` runtime is on track to be deprecated at the end of this year, we are switching to use the `provided.al2` runtime instead. I tested via running the SOCI snapshotter via the SOCI index built both before and after the change and confirmed that they had identical outputs.

Ran a test on Fargate via running the snapshot after the change and let it run for a few minutes after startup and ensured nothing crashed.

### Reviewers
@turan18 or @Kern-- 
