### PR TITLE
Fix documented permission requirements

### DIFF
--- a/docs/deployment_guide/partner_editable/pre_deployment.adoc
+++ b/docs/deployment_guide/partner_editable/pre_deployment.adoc
@@ -21,7 +21,7 @@
                 "events:DeleteRule",
                 "events:RemoveTargets"
             ],
-            "Resource": "arn:aws:events:<Region>:<AccountId>:rule/ECRImageActionEventBridgeRule",
+            "Resource": "arn:aws:events:<Region>:<AccountId>:rule/ECRImageActionEventBridgeRule"
         }
     ]
 }
@@ -42,7 +42,7 @@
             ],
             "Resource": [
                 "arn:aws:s3:::aws-quickstart-<Region>/*soci_index_generator_lambda.zip",
-                "arn:aws:s3:::aws-quickstart-<Region>/*ecr_image_action_event_filtering_lambda_function.zip"
+                "arn:aws:s3:::aws-quickstart-<Region>/*ecr-image-action-event-filtering/lambda.zip"
             ]
         }
     ]
@@ -65,11 +65,13 @@
                 "lambda:UpdateFunctionConfiguration",
                 "lambda:AddPermission",
                 "lambda:DeleteFunction",
-                "lambda:RemovePermission"
+                "lambda:RemovePermission",
+                "lambda:InvokeFunction"
             ],
             "Resource": [
                 "arn:aws:lambda:<Region>:<AccountId>:function:*-ECRImageActionEventFilteringLambda-*",
-                "arn:aws:lambda:<Region>:<AccountId>:function:*-SociIndexGeneratorLambda-*"
+                "arn:aws:lambda:<Region>:<AccountId>:function:*-SociIndexGeneratorLambda-*",
+                "arn:aws:lambda:<Region>:<AccountId>:function:RepositoryNameParsingLambda"
             ]
         }
     ]
@@ -96,8 +98,9 @@
                 "iam:DeleteRolePolicy"
             ],
             "Resource": [
-                "arn:aws:iam::<AccountId>:role/*-ECRImageActionEventFilteringLambdaRole*",
-                "arn:aws:iam::<AccountId>:role/*-SociIndexGeneratorLambdaRole*"
+                "arn:aws:iam::<AccountId>:role/*-ECRImageActionEventFilteringLambdaRole-*",
+                "arn:aws:iam::<AccountId>:role/*-SociIndexGeneratorLambdaRole-*",
+                "arn:aws:iam::<AccountId>:role/*-RepositoryNameParsingLambdaRole-*"
             ]
         }
     ]
@@ -108,6 +111,10 @@ Notes:
 
 * `<AccountId>` should be replaced by the AWS Account ID of the account you’re deploying to and `<Region>` should be replaced by the region you’re deploying to (example: us-east-1).
 
-* The role name _ECRImageActionEventFilteringLambdaRole_, specified in the resource section of the IAM permissions above, will be truncated if the name of your stack is greater than 12 characters.
+* The Lambda function name _ECRImageActionEventFilteringLambda_, specified in the resource section of the Lambda permission above, will be truncated if the name of your stack is greater than 15 characters.
 
-* The role name _SociIndexGeneratorLambdaRole_, specified in the resource section of the IAM permissions above, will be truncated if the name of your stack is greater than 22 characters.
+* The role name _ECRImageActionEventFilteringLambdaRole_, specified in the resource section of the IAM permissions above, will be truncated if the name of your stack is greater than 11 characters.
+
+* The role name _SociIndexGeneratorLambdaRole_, specified in the resource section of the IAM permissions above, will be truncated if the name of your stack is greater than 21 characters.
+
+* The role name _RepositoryNameParsingLambdaRole_, specified in the resource section of the IAM permissions above, will be truncated if the name of your stack is greater than 18 characters.


### PR DESCRIPTION
### Related Issue
N/A

### Proposed Changes
The documentation around the minimum permissions needed to deploy the CloudFormation template drifted from the template itself and were missing several resources/permissions. This adds those resources as well as a note that the resource names might be truncated relative to the permissions listed if the stack name is long.

### Reviewers
@turan18 